### PR TITLE
Changed 'GLNS' to "GLNS"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ julia> import Pkg
 ```
 3. Install GLNS Package for Julia
 ```
-julia> Pkg.add('GLNS')
+julia> Pkg.add("GLNS")
 ```


### PR DESCRIPTION
Changed Pkg.add('GLNS') to Pkg.add("GLNS") to prevent the following error:

> ERROR: syntax: invalid character literal
